### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: c
 sudo: false
 compiler:
   - gcc
+os:
+  - linux
+  - osx
 #env:
 #install:
 #- if [ "$CC" = "gcc" ]; then export CC="gcc-4.9"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
   - gcc
 os:
   - linux
-  - osx
+  #- osx
 #env:
 #install:
 #- if [ "$CC" = "gcc" ]; then export CC="gcc-4.9"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: c
+sudo: false
+compiler:
+  - gcc
+#env:
+#install:
+#- if [ "$CC" = "gcc" ]; then export CC="gcc-4.9"; fi
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    #packages:
+    #- gcc-4.9
+    #- clang
+script:
+  - make
+  - ./PathFinder.x -x 1kx750.adj_list
+  - ./PathFinder.x -x 2kx750.adj_list
+  - ./PathFinder.x -x 4kx750.adj_list
+  - ./PathFinder.x -x 6kx750.adj_list
+  - ./PathFinder.x -x 8kx750.adj_list
+  - ./PathFinder.x -x 10kx750.adj_list
+#after_failure:
+#  - echo "Sad panda"
+notifications:
+  email:
+    recipients:
+      - jeff.science@gmail.com
+    on_success: [change]
+    on_failure: [always]

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,14 @@ addons:
     #- gcc-4.9
     #- clang
 script:
+  - cd ref/
   - make
-  - ./PathFinder.x -x 1kx750.adj_list
-  - ./PathFinder.x -x 2kx750.adj_list
-  - ./PathFinder.x -x 4kx750.adj_list
-  - ./PathFinder.x -x 6kx750.adj_list
-  - ./PathFinder.x -x 8kx750.adj_list
-  - ./PathFinder.x -x 10kx750.adj_list
+  - ./PathFinder.x -x ../data/scaleData/1kx750.adj_list
+  - ./PathFinder.x -x ../data/scaleData/2kx750.adj_list
+  - ./PathFinder.x -x ../data/scaleData/4kx750.adj_list
+  - ./PathFinder.x -x ../data/scaleData/6kx750.adj_list
+  - ./PathFinder.x -x ../data/scaleData/8kx750.adj_list
+  - ./PathFinder.x -x ../data/scaleData/10kx750.adj_list
 #after_failure:
 #  - echo "Sad panda"
 notifications:

--- a/ref/Makefile
+++ b/ref/Makefile
@@ -32,22 +32,14 @@
 
 #-----------------------------------------------------------------------
 
-#CC=cc
-CC=gcc
+CC	:= cc
+CFLAGS	:= -O2 -fopenmp
+LIBS 	:= -lm
 
-CFLAGS = $(OPT)
-#CFLAGS += -openmp
-CFLAGS += -fopenmp
 #CFLAGS += -D_USE_PAT_API
 
 LD      = $(CC)
 LDFLAGS = $(CFLAGS)
-
-# Optimization
-OPT = -O3
-OPT = -g
-
-LIBS = -lgomp -lm
 
 include make_targets
 


### PR DESCRIPTION
You will need to register Mantevo with Travis using your Github credentials to use Travis CI, but it is a really nice way to ensure your codes are building and running correctly in standard environments.

Ubuntu + GCC 4.6.3 is passing (https://travis-ci.org/jeffhammond/PathFinder/builds/165582194) but Mac isn't because of lack of OpenMP support in the system compiler.  I can fix this, but I don't know if anyone cares.
