### PR TITLE
fix c99 compliance issues (new)

### DIFF
--- a/ref/main.c
+++ b/ref/main.c
@@ -48,6 +48,7 @@
 #include "vectorUtils.h"
 #include "statistics.h"
 #include "configuration.h"
+#include "yaml.h"
 
 #ifdef QT
    #include "qThreadSearch.h"

--- a/ref/parsing.c
+++ b/ref/parsing.c
@@ -525,13 +525,13 @@ char **parseSignature( char *data )
         labels[labelCount] = NULL; /* terminate the array */
     }
 
-    /* Debug print out * /
+#ifdef DEBUG
     printf ( "\nSignature: ");
     for ( i = 0; labels[i] != NULL; ++i )
     {
         printf ( "%s ", labels[i] );
     }
-    /* end Debug */
+#endif
 
     return labels;
 }

--- a/ref/searchAlgorithms.c
+++ b/ref/searchAlgorithms.c
@@ -610,7 +610,7 @@ int findAndLogAllPossibleLegs(Graph *graph, SearchOptions *options)
     YAMLWriteInt("Signatures Found", found);
     YAMLWriteString("Search Time", timeStr);
 
-    /* debug --> * /
+#ifdef DEBUG
     printf ("max threads still:%d\n", maxThreads);
     for ( i = 0; i < maxThreads; ++i )
     {
@@ -622,7 +622,7 @@ int findAndLogAllPossibleLegs(Graph *graph, SearchOptions *options)
             printf("\n");
         }
     }
-    /* <-- debug */
+#endif
 
     /* At some point, we will want to use the FullPath argument and pass it along to
      * buildGraphFromPaths. Until then, however, we're only going to build the most

--- a/ref/searchAlgorithms.c
+++ b/ref/searchAlgorithms.c
@@ -47,6 +47,7 @@
 #include "utils.h"
 #include "graphGen.h"
 #include "statistics.h"
+#include "yaml.h"
 
 
 extern double currentTime();
@@ -548,7 +549,9 @@ int findAndLogAllPossibleLegs(Graph *graph, SearchOptions *options)
         {
             maxThreads = omp_get_num_threads();
             options->multiThreaded = maxThreads > 1;
-            /* debug * /printf( "%d total threads, this one is %d\n", maxThreads, myThread ); /* debug */
+#ifdef DEBUG
+            printf( "%d total threads, this one is %d\n", maxThreads, myThread );
+#endif
             lastingResults = malloc((maxThreads+1) * sizeof(NodeVecVec*) );
             lastingResults[maxThreads] = 0; /* Null terminated to avoid having to keep track of bitsNeeded */
         }
@@ -580,11 +583,11 @@ int findAndLogAllPossibleLegs(Graph *graph, SearchOptions *options)
                     fullIntSignature[1] = j;
                     NodePtrVec *result = NodePtrVec_new(16);
                     Bitfield *visited = Bitfield_new(graph->totalNodes);
-                    /* debug ---> * /
+#ifdef DEBUG
                     printf( "Searching for %s(%d) ~~~> %s\n", fullSignature[0],
                             graph->systemCallMap->vector[i]->nodes->vector[k]->id,
                             fullSignature[1]);
-                    /* <-- debug */
+#endif
                     findAndRecordAllPaths( graph->systemCallMap->vector[i]->nodes->vector[k], &fullSignature[1],
                             &fullIntSignature[1], result, visited, myResults, options );
                     Bitfield_delete(visited);

--- a/ref/searchAlgorithms.h
+++ b/ref/searchAlgorithms.h
@@ -101,6 +101,10 @@ int findAndLogAllPossibleLegs( Graph *graph, SearchOptions *options );
  * does multiple signature searches against multiple files 
  */
  
+#ifdef QT
 void doMultiSearchesQT(Configuration *config);
+#else
+void doMultiSearches(Configuration *config);
+#endif
 
 #endif /* SEARCHALGORITHMS_H_ */


### PR DESCRIPTION
Recent releases of Clang and GCC have changed the default language from C89 (i.e. -std=gnu89) to C11 (i.e. -std=gnu11).

This PR address issues with undeclared functions and nested comments so that the code compiles cleanly as C99 or C11 code.

This PR replaces https://github.com/Mantevo/PathFinder/pull/4
